### PR TITLE
[CBP-45084] Migrate kaniko build to cb-internal-shared-actions/build@v8

### DIFF
--- a/.cloudbees/workflows/workflow.yml
+++ b/.cloudbees/workflows/workflow.yml
@@ -30,32 +30,18 @@ jobs:
             exit 1
           fi
 
-      - name: Login to AWS
-        uses: cloudbees-io/configure-aws-credentials@v1
-        id: aws-login
+      - id: build-image
+        name: Build, scan and push to ECR
+        uses: calculi-corp/cb-internal-shared-actions/build@v8
         with:
-          aws-region: us-east-1
-          role-to-assume: ${{ vars.oidc_staging_iam_role }}
-          role-duration-seconds: "3600" # optionally set the duration of the login token
-
-      - name: Configure container registry for Staging ECR
-        uses: https://github.com/cloudbees-io/configure-ecr-credentials@v1
-
-      - name: Build and publish
-        id: build-image
-        uses: cloudbees-io/kaniko@v1
-        with:
-          destination: 020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/configure-eks-credentials:${{ cloudbees.scm.sha }}${{ cloudbees.scm.branch == 'main' && ',020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/configure-eks-credentials:latest' || ''}}
-          labels: maintainer=sdp-pod-3,email=engineering@cloudbees.io
-
-      - id: slsa-attestation
-        name: Generate SLSA attestation
-        uses: https://github.com/calculi-corp/slsa-attestation@v1
-        with:
-          image-digest: 020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/configure-eks-credentials@${{ steps.build-image.outputs.digest }}
-          aws-role-to-assume: ${{ vars.oidc_staging_iam_role }}
-          aws-region: us-east-1
-          aws-kms-alias: cbp-dev-kms-key-cosign
+          go-binary-build: "true"
+          go-binary-name: configure-eks-credentials
+          kaniko-build: "true"
+          run-unit-test: "false"
+          registry-url: 020229604682.dkr.ecr.us-east-1.amazonaws.com
+          registry-image-name: actions/configure-eks-credentials
+          registry-type: ECR
+          oidc-iam-role: ${{ vars.oidc_staging_iam_role }}
 
   compat-check:
     needs: ["build"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,25 +3,16 @@ ARG AWS_IAM_AUTHENTICATOR_VERSION=0.7.14
 FROM alpine:3.23 AS certs
 RUN apk add -U --no-cache ca-certificates
 
-FROM golang:1.26.2-alpine3.23 AS build
-WORKDIR /work
-COPY go.mod* go.sum* ./
-RUN go mod download
-COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /build-out/ .
-
-
 FROM alpine:3.23 AS awsiamauth
 ARG AWS_IAM_AUTHENTICATOR_VERSION
 WORKDIR /
 RUN wget -q https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${AWS_IAM_AUTHENTICATOR_VERSION}/aws-iam-authenticator_${AWS_IAM_AUTHENTICATOR_VERSION}_linux_amd64 -O aws-iam-authenticator && \
     chmod 755 aws-iam-authenticator
 
-
 FROM scratch
 COPY --from=awsiamauth /aws-iam-authenticator /usr/bin/
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=build /build-out/* /usr/bin/
+COPY configure-eks-credentials /usr/bin/
 WORKDIR /cloudbees/home
 ENV HOME=/cloudbees/home
 ENV PATH=/usr/bin


### PR DESCRIPTION
Replace the `kaniko@v1` + AWS/ECR login + `slsa-attestation` pipeline with a single `calculi-corp/cb-internal-shared-actions/build@v8` (services variant) call. Move go build into the workflow via `go-binary-build: true`. Dockerfile slimmed to runtime-only.

Generated by `/upgrade-shared-actions`.

Tracking: CBP-45084 (Upgrade Kaniko and V.x < V8 to shared actions V8: compliance, io).
