### PR TITLE
[CBP-46306] Remove cluster suffix

### DIFF
--- a/.cloudbees/workflows/workflow.yml
+++ b/.cloudbees/workflows/workflow.yml
@@ -68,10 +68,13 @@ jobs:
           aws-region: us-east-1
           role-to-assume: ${{ vars.oidc_staging_iam_role }}
           role-duration-seconds: "3600" # optionally set the duration of the login token
+      - name: Check current AWS identity
+        uses: docker://public.ecr.aws/aws-cli/aws-cli
+        run: |
+          aws sts get-caller-identity
       - uses: ./.cloudbees/testing
         with:
           name: ${{ vars.tekton_east_cluster_name }}-blue
-          role-to-assume: ${{ vars.oidc_staging_iam_role }}
           alias: mycontext
       - uses: docker://alpine/k8s:1.27.3
         run: |
@@ -93,10 +96,13 @@ jobs:
           aws-region: us-west-2
           role-to-assume: ${{ vars.oidc_staging_iam_role }}
           role-duration-seconds: "3600" # optionally set the duration of the login token
+      - name: Check current AWS identity
+        uses: docker://public.ecr.aws/aws-cli/aws-cli
+        run: |
+          aws sts get-caller-identity
       - uses: ./.cloudbees/testing
         with:
           name: ${{ vars.tekton_east_cluster_name }}-blue
-          role-to-assume: ${{ vars.oidc_staging_iam_role }}
           alias: mycontext
           region: us-east-1
       - uses: docker://alpine/k8s:1.27.3

--- a/.cloudbees/workflows/workflow.yml
+++ b/.cloudbees/workflows/workflow.yml
@@ -71,6 +71,7 @@ jobs:
       - uses: ./.cloudbees/testing
         with:
           name: ${{ vars.tekton_east_cluster_name }}-blue
+          role-to-assume: ${{ vars.oidc_staging_iam_role }}
           alias: mycontext
       - uses: docker://alpine/k8s:1.27.3
         run: |
@@ -95,6 +96,7 @@ jobs:
       - uses: ./.cloudbees/testing
         with:
           name: ${{ vars.tekton_east_cluster_name }}-blue
+          role-to-assume: ${{ vars.oidc_staging_iam_role }}
           alias: mycontext
           region: us-east-1
       - uses: docker://alpine/k8s:1.27.3

--- a/.cloudbees/workflows/workflow.yml
+++ b/.cloudbees/workflows/workflow.yml
@@ -68,13 +68,9 @@ jobs:
           aws-region: us-east-1
           role-to-assume: ${{ vars.oidc_staging_iam_role }}
           role-duration-seconds: "3600" # optionally set the duration of the login token
-      - name: Check current AWS identity
-        uses: docker://public.ecr.aws/aws-cli/aws-cli
-        run: |
-          aws sts get-caller-identity
       - uses: ./.cloudbees/testing
         with:
-          name: ${{ vars.tekton_east_cluster_name }}-blue
+          name: ${{ vars.tekton_east_cluster_name }}
           alias: mycontext
       - uses: docker://alpine/k8s:1.27.3
         run: |
@@ -96,13 +92,9 @@ jobs:
           aws-region: us-west-2
           role-to-assume: ${{ vars.oidc_staging_iam_role }}
           role-duration-seconds: "3600" # optionally set the duration of the login token
-      - name: Check current AWS identity
-        uses: docker://public.ecr.aws/aws-cli/aws-cli
-        run: |
-          aws sts get-caller-identity
       - uses: ./.cloudbees/testing
         with:
-          name: ${{ vars.tekton_east_cluster_name }}-blue
+          name: ${{ vars.tekton_east_cluster_name }}
           alias: mycontext
           region: us-east-1
       - uses: docker://alpine/k8s:1.27.3


### PR DESCRIPTION
In prod the defined property uses the full cluster name, so appending a suffix is no longer necessary.