### PR TITLE
[CBP-45084] switch to build/action@v8 (action variant)

### DIFF
--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -47,7 +47,7 @@ runs:
   using: composite
   steps:
     - name: Configure EKS Credentials For CloudBees Automations
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/configure-eks-credentials:${{ action.scm.sha }}
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/configure-eks-credentials:${{ file.scm.sha }}
       env:
         INPUT_NAME: ${{ inputs.name }}
         INPUT_REGION: ${{ inputs.region }}

--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -47,7 +47,7 @@ runs:
   using: composite
   steps:
     - name: Configure EKS Credentials For CloudBees Automations
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/configure-eks-credentials:${{ file.scm.sha }}
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/configure-eks-credentials:${{ action.scm.sha }}
       env:
         INPUT_NAME: ${{ inputs.name }}
         INPUT_REGION: ${{ inputs.region }}

--- a/.cloudbees/workflows/workflow.yml
+++ b/.cloudbees/workflows/workflow.yml
@@ -32,7 +32,7 @@ jobs:
 
       - id: build-image
         name: Build, scan and push to ECR
-        uses: calculi-corp/cb-internal-shared-actions/build@v8
+        uses: calculi-corp/cb-internal-shared-actions/build/action@v8
         with:
           go-binary-build: "true"
           go-binary-name: configure-eks-credentials


### PR DESCRIPTION
Switch this repo from `calculi-corp/cb-internal-shared-actions/build@v8`
(services variant) to `build/action@v8` (action variant) — the variant
intended for cloudbees-io action repos.

Follows the pattern Kirk established in
[cloudbees-io/configure-oci-credentials#33](https://github.com/cloudbees-io/configure-oci-credentials/pull/33).
The producer side (clean `image:${gitsha}` tag prepended to the destination
list) shipped in
[calculi-corp/cb-internal-shared-actions#123](https://github.com/calculi-corp/cb-internal-shared-actions/pull/123).

### Edits applied

- `.cloudbees/workflows/workflow.yml`: `build@v8` → `build/action@v8`
- `.cloudbees/testing/action.yml`: `${{ action.scm.sha }}` → `${{ file.scm.sha }}` so the testing action references its own file SHA. Producer PR #123 emits `image:${gitsha}` as the first destination tag, so this resolves cleanly.

### Edits NOT applied (already in good state)

- `permissions:` block already has `scm-token-org: read` (top-level + job-level).

Tracking: CBP-45084